### PR TITLE
Create funding.md

### DIFF
--- a/guidelines/funding.md
+++ b/guidelines/funding.md
@@ -1,37 +1,32 @@
-# Funding guidelines
+# Funding Guidelines
 
-This document provides information on funding made available by the AIM RSF for the Early Career Researcher (ECR) Day to take place at the Alan Turing Institute on 23 November 2023.
+This document outlines the funding opportunities provided by the AIM RSF (Alan Turing Institute Research Support Fund) for the Early Career Researcher (ECR) Day scheduled for **November 23, 2023,** at the Alan Turing Institute.
 
 ## Accessibility Fund
-We are able to provide an Accessibility Fund to support individuals with specific needs.
-This fund is available to a maximum of ten applicants, each eligible for financial assistance of up to £250.
-To apply for the Accessibility Fund, it is essential to clearly outline what specific accommodations are required and provide a compelling explanation of why they are needed.
-This information ensures that we can best address your unique accessibility requirements and offer the necessary support to make your experience as comfortable and accessible as possible.
+We are delighted to offer an Accessibility Fund designed to support individuals with specific needs. This fund extends to a maximum of ten applicants, each eligible for financial assistance of up to £250. To apply for the Accessibility Fund, it is essential to clearly articulate your specific accommodation requirements and provide a compelling explanation of why these accommodations are necessary. Additionally, please confirm your ability to provide receipts. This information enables us to tailor our support to ensure your experience is as comfortable and accessible as possible. Examples of accessibility needs may include childcare, an extra night's stay at a hotel due to caregiving responsibilities, and more.
 
 ## Hotel Expenses
-The RSF can arrange hotel accommodation for a maximum of one day, if it was explicitly requested in the registration form.
-However, if you applied for the accessibility fund, which includes a request for an extra night, this exception would apply.
+The RSF can arrange hotel accommodation for a maximum of one day if explicitly requested in the registration form. However, if you have applied for the accessibility fund, which includes a request for an additional night, this exception will apply.
 
 ## Travel Expenses
-**As part of the ECR day arrangements, the RSF is able to subsidise travel costs to a maximum of £150 (incl. VAT) per RSF-funded delegate place.**
+**As part of the ECR Day arrangements, the RSF is pleased to offer a travel cost subsidy of up to £150 (inclusive of VAT) per ECR.**
 
-RSF team colleagues based at The Alan Turing Institute are responsible for booking travel arrangements to and from the Turing in line with The Alan Turing Institute’s internal Travel and Expenses Policy.
+The RSF team, based at The Alan Turing Institute, will manage the booking of travel arrangements to and from the Turing, in compliance with The Alan Turing Institute’s internal Travel and Expenses Policy.
 
-AIM Consortium members are responsible for booking and paying for their own travel arrangements to and from the Turing, and for the prompt completion and submission of expenses claims thereafter (see below for guidance).
+There are two options for reimbursement:
+- If the ECR are purchasing tickets through their internal institution system, individual consortia are asked to collate all travel expenses for their research group and to submit a single collective claim to the RSF team for reimbursement via the three forms (not through purchase order). Consortia will need to fill them only once. The value of the ticket should be in alignment with Turing Travel policy. RSF will then administer this to the value of £150 (maximum) for each consortium member travelling. 
+- If the ECR is paying on their own, each will need to submit individually by filling in the 3 forms below.
 
-Where possible, individual consortia are asked to collate all travel expenses for their research group and to submit a single collective claim to the RSF team for reimbursement.
-The RSF will then administer this to the value of £150 (maximum) for each consortium member traveling.
+Whenever feasible, we encourage individual consortia to consolidate all travel expenses for their research group and submit a single collective claim to the RSF team for reimbursement. The RSF will then process reimbursements up to the value of £150 for each consortium member who traveled.
 
-Where possible, the most economic and low-carbon means of travel should be chosen and delegates travelling by train should attempt to reduce the cost of travel by using existing travel cards and discounts.
-Claimants traveling by train must also use standard class (unless a cheaper fare is available in first class).
+In line with our commitment to sustainability, we strongly recommend selecting the most cost-effective and environmentally friendly means of travel. Delegates travelling by train should explore cost-saving options, such as utilising existing travel cards and discounts. Claimants traveling by train must use standard class unless a cheaper fare in first class is available.
 
-To **claim back your expenses**, we need **three types of files** from you. Please click on the links below to access the files:
-- Receipts (images/PDFs): Please include clear photos or copies of your receipts, and include the itemised list version of the receipt where possible.
-- [Expense form (Excel)](https://az659834.vo.msecnd.net/eventsairwesteuprod/production-uobevents-public/2662fbd88e3f40e09d5f4bc3ab9ae9c5): Please complete this in the currency of the expense that occurred. If you can’t do this, please note it in the email back to us, and we'll fix it. You need to add your sort code and bank details, date, and Gross Value accurately. If it's not filled in, we won't be able to process your reimbursement.
-- [Travel & expenses policy (PDF/jpg, signed)](https://az659834.vo.msecnd.net/eventsairwesteuprod/production-uobevents-public/55742e599b004367b24d306d7ad73916): We cannot process your expenses without this, so please don't leave it out. All your bank details need to be filled in except for the Name of the Turing Approver/Supervisor. 
+To initiate the **expenses reimbursement process**, we require **three types of documents** from you. Please click on the links below to access the necessary files:
 
-**_If you're sending the forms and receipts to RSF team (aimrsf@turing.ac.uk) independently and not through your consortium project manager, please make sure that you use DocuSign and complete all docs.
-You should have received an email from DocuSign with all docs._**
+- **Receipts (images/PDFs):** Include clear photos or copies of your receipts, ensuring that the itemized list version of the receipt is visible where available.
+- **[Expense form (Excel)](https://az659834.vo.msecnd.net/eventsairwesteuprod/production-uobevents-public/2662fbd88e3f40e09d5f4bc3ab9ae9c5):** Complete this form in the currency corresponding to the expense. If this is not possible, please indicate this in your email to us, and we will assist you. Ensure accurate inclusion of your sort code, bank details, date, and Gross Value. Incomplete forms will result in processing delays.
+- **[Travel & Expenses Policy (PDF/jpg, signed)](https://az659834.vo.msecnd.net/eventsairwesteuprod/production-uobevents-public/55742e599b004367b24d306d7ad73916):** This document is essential for processing your expenses; therefore, please do not omit it. Ensure all bank details are filled in, with the exception of the Name of the Turing Approver/Supervisor.
 
-*Forms and receipts must be submitted within __3-4 weeks__ to aimrsf@turing.ac.uk by either the Consortium Project Manager or by delegates themselves.
-If you are claiming for mileages, please add a Google map showing the mileages and review the Travel policy to find the rate for mileages.*
+**_If you are sending the forms and receipts to the RSF team (aimrsf@turing.ac.uk) independently, rather than through your consortium project manager, please utilize DocuSign and complete all documents. You should have received an email from DocuSign containing all the necessary documents._**
+
+*Forms and receipts must be submitted to aimrsf@turing.ac.uk within __3 weeks__ from the conclusion of your travel. Submissions can be made by either the Consortium Project Manager or individual delegates. If you are claiming mileage expenses, please include a Google map displaying the mileage calculation, and consult the Travel policy for mileage rates.*

--- a/guidelines/funding.md
+++ b/guidelines/funding.md
@@ -27,8 +27,8 @@ Claimants traveling by train must also use standard class (unless a cheaper fare
 
 To **claim back your expenses**, we need **three types of files** from you. Please click on the links below to access the files:
 - Receipts (images/PDFs): Please include clear photos or copies of your receipts, and include the itemised list version of the receipt where possible.
-- Expense form (Excel): Please complete this in the currency of the expense that occurred. If you can’t do this, please note it in the email back to us, and we'll fix it. You need to add your sort code and bank details, date, and Gross Value accurately. If it's not filled in, we won't be able to process your reimbursement.
-- Travel & expenses policy (PDF/jpg, signed): We cannot process your expenses without this, so please don't leave it out. All your bank details need to be filled in except for the Name of the Turing Approver/Supervisor. 
+- [Expense form (Excel)](https://az659834.vo.msecnd.net/eventsairwesteuprod/production-uobevents-public/2662fbd88e3f40e09d5f4bc3ab9ae9c5): Please complete this in the currency of the expense that occurred. If you can’t do this, please note it in the email back to us, and we'll fix it. You need to add your sort code and bank details, date, and Gross Value accurately. If it's not filled in, we won't be able to process your reimbursement.
+- [Travel & expenses policy (PDF/jpg, signed)](https://az659834.vo.msecnd.net/eventsairwesteuprod/production-uobevents-public/55742e599b004367b24d306d7ad73916): We cannot process your expenses without this, so please don't leave it out. All your bank details need to be filled in except for the Name of the Turing Approver/Supervisor. 
 
 **_If you're sending the forms and receipts to RSF team (aimrsf@turing.ac.uk) independently and not through your consortium project manager, please make sure that you use DocuSign and complete all docs.
 You should have received an email from DocuSign with all docs._**

--- a/guidelines/funding.md
+++ b/guidelines/funding.md
@@ -15,7 +15,7 @@ The RSF team, based at The Alan Turing Institute, will manage the booking of tra
 
 There are two options for reimbursement:
 
-- If the ECR are purchasing tickets through their internal institution system, individual consortia are asked to collate all travel expenses for their research group and to submit a single collective claim to the RSF team for reimbursement via the three forms (not through a purchase order). Consortia will need to fill them only once. The value of the ticket should be in alignment with Turing Travel policy. RSF will then administer this to the value of £150 (maximum) for each consortium member traveling.
+- If the ECRs are purchasing tickets through their internal institution system, individual consortia are asked to collate all travel expenses for their research group and to submit a single collective claim to the RSF team for reimbursement via the three forms (not through a purchase order). Consortia will need to fill them only once. The value of the ticket should be in alignment with Turing Travel policy. RSF will then administer this to the value of £150 (maximum) for each consortium member travelling.
 
 - If the ECR is paying on their own, each will need to submit individually by filling in the 3 forms below.
 

--- a/guidelines/funding.md
+++ b/guidelines/funding.md
@@ -1,0 +1,37 @@
+# Funding guidelines
+
+This document provides information on funding made available by the AIM RSF for the Early Career Researcher (ECR) Day to take place at the Alan Turing Institute on 23 November 2023.
+
+## Accessibility Fund
+We are able to provide an Accessibility Fund to support individuals with specific needs.
+This fund is available to a maximum of ten applicants, each eligible for financial assistance of up to £250.
+To apply for the Accessibility Fund, it is essential to clearly outline what specific accommodations are required and provide a compelling explanation of why they are needed.
+This information ensures that we can best address your unique accessibility requirements and offer the necessary support to make your experience as comfortable and accessible as possible.
+
+## Hotel Expenses
+The RSF can arrange hotel accommodation for a maximum of one day, if it was explicitly requested in the registration form.
+However, if you applied for the accessibility fund, which includes a request for an extra night, this exception would apply.
+
+## Travel Expenses
+**As part of the ECR day arrangements, the RSF is able to subsidise travel costs to a maximum of £150 (incl. VAT) per RSF-funded delegate place.**
+
+RSF team colleagues based at The Alan Turing Institute are responsible for booking travel arrangements to and from the Turing in line with The Alan Turing Institute’s internal Travel and Expenses Policy.
+
+AIM Consortium members are responsible for booking and paying for their own travel arrangements to and from the Turing, and for the prompt completion and submission of expenses claims thereafter (see below for guidance).
+
+Where possible, individual consortia are asked to collate all travel expenses for their research group and to submit a single collective claim to the RSF team for reimbursement.
+The RSF will then administer this to the value of £150 (maximum) for each consortium member traveling.
+
+Where possible, the most economic and low-carbon means of travel should be chosen and delegates travelling by train should attempt to reduce the cost of travel by using existing travel cards and discounts.
+Claimants traveling by train must also use standard class (unless a cheaper fare is available in first class).
+
+To **claim back your expenses**, we need **three types of files** from you. Please click on the links below to access the files:
+- Receipts (images/PDFs): Please include clear photos or copies of your receipts, and include the itemised list version of the receipt where possible.
+- Expense form (Excel): Please complete this in the currency of the expense that occurred. If you can’t do this, please note it in the email back to us, and we'll fix it. You need to add your sort code and bank details, date, and Gross Value accurately. If it's not filled in, we won't be able to process your reimbursement.
+- Travel & expenses policy (PDF/jpg, signed): We cannot process your expenses without this, so please don't leave it out. All your bank details need to be filled in except for the Name of the Turing Approver/Supervisor. 
+
+**_If you're sending the forms and receipts to RSF team (aimrsf@turing.ac.uk) independently and not through your consortium project manager, please make sure that you use DocuSign and complete all docs.
+You should have received an email from DocuSign with all docs._**
+
+*Forms and receipts must be submitted within __3-4 weeks__ to aimrsf@turing.ac.uk by either the Consortium Project Manager or by delegates themselves.
+If you are claiming for mileages, please add a Google map showing the mileages and review the Travel policy to find the rate for mileages.*

--- a/guidelines/funding.md
+++ b/guidelines/funding.md
@@ -14,17 +14,23 @@ The RSF can arrange hotel accommodation for a maximum of one day if explicitly r
 The RSF team, based at The Alan Turing Institute, will manage the booking of travel arrangements to and from the Turing, in compliance with The Alan Turing Institute’s internal Travel and Expenses Policy.
 
 There are two options for reimbursement:
-- If the ECR are purchasing tickets through their internal institution system, individual consortia are asked to collate all travel expenses for their research group and to submit a single collective claim to the RSF team for reimbursement via the three forms (not through purchase order). Consortia will need to fill them only once. The value of the ticket should be in alignment with Turing Travel policy. RSF will then administer this to the value of £150 (maximum) for each consortium member travelling. 
+
+- If the ECR are purchasing tickets through their internal institution system, individual consortia are asked to collate all travel expenses for their research group and to submit a single collective claim to the RSF team for reimbursement via the three forms (not through a purchase order). Consortia will need to fill them only once. The value of the ticket should be in alignment with Turing Travel policy. RSF will then administer this to the value of £150 (maximum) for each consortium member traveling.
+
 - If the ECR is paying on their own, each will need to submit individually by filling in the 3 forms below.
+
+Please note if the consortia is paying for travel expenses through their internal system and can't fill in the forms and will need to invoice us through a Purchase Order, AIM RSF need to be notified by the 14th of Sept.
 
 Whenever feasible, we encourage individual consortia to consolidate all travel expenses for their research group and submit a single collective claim to the RSF team for reimbursement. The RSF will then process reimbursements up to the value of £150 for each consortium member who traveled.
 
-In line with our commitment to sustainability, we strongly recommend selecting the most cost-effective and environmentally friendly means of travel. Delegates travelling by train should explore cost-saving options, such as utilising existing travel cards and discounts. Claimants traveling by train must use standard class unless a cheaper fare in first class is available.
+In line with our commitment to sustainability, we strongly recommend selecting the most cost-effective and environmentally friendly means of travel. Delegates traveling by train should explore cost-saving options, such as utilizing existing travel cards and discounts. Claimants traveling by train must use standard class unless a cheaper fare in first class is available.
 
 To initiate the **expenses reimbursement process**, we require **three types of documents** from you. Please click on the links below to access the necessary files:
 
 - **Receipts (images/PDFs):** Include clear photos or copies of your receipts, ensuring that the itemized list version of the receipt is visible where available.
+
 - **[Expense form (Excel)](https://az659834.vo.msecnd.net/eventsairwesteuprod/production-uobevents-public/2662fbd88e3f40e09d5f4bc3ab9ae9c5):** Complete this form in the currency corresponding to the expense. If this is not possible, please indicate this in your email to us, and we will assist you. Ensure accurate inclusion of your sort code, bank details, date, and Gross Value. Incomplete forms will result in processing delays.
+
 - **[Travel & Expenses Policy (PDF/jpg, signed)](https://az659834.vo.msecnd.net/eventsairwesteuprod/production-uobevents-public/55742e599b004367b24d306d7ad73916):** This document is essential for processing your expenses; therefore, please do not omit it. Ensure all bank details are filled in, with the exception of the Name of the Turing Approver/Supervisor.
 
 **_If you are sending the forms and receipts to the RSF team (aimrsf@turing.ac.uk) independently, rather than through your consortium project manager, please utilize DocuSign and complete all documents. You should have received an email from DocuSign containing all the necessary documents._**

--- a/guidelines/funding.md
+++ b/guidelines/funding.md
@@ -19,7 +19,7 @@ There are two options for reimbursement:
 
 - If the ECR is paying on their own, each will need to submit individually by filling in the 3 forms below.
 
-Please note if the consortia is paying for travel expenses through their internal system and can't fill in the forms and will need to invoice us through a Purchase Order, AIM RSF (aimrsf@turing.ac.uk) need to be notified by the 14th of Sept to discuss the options.
+Please note if the consortia are paying for travel expenses through their internal system and can't fill in the forms and will need to invoice us through a Purchase Order, the AIM RSF (aimrsf@turing.ac.uk) will need to be notified by **14 September** to discuss the options.
 
 Whenever feasible, we encourage individual consortia to consolidate all travel expenses for their research group and submit a single collective claim to the RSF team for reimbursement. The RSF will then process reimbursements up to the value of £150 for each consortium member who traveled.
 

--- a/guidelines/funding.md
+++ b/guidelines/funding.md
@@ -19,7 +19,7 @@ There are two options for reimbursement:
 
 - If the ECR is paying on their own, each will need to submit individually by filling in the 3 forms below.
 
-Please note if the consortia is paying for travel expenses through their internal system and can't fill in the forms and will need to invoice us through a Purchase Order, AIM RSF need to be notified by the 14th of Sept.
+Please note if the consortia is paying for travel expenses through their internal system and can't fill in the forms and will need to invoice us through a Purchase Order, AIM RSF (aimrsf@turing.ac.uk) need to be notified by the 14th of Sept to discuss the options.
 
 Whenever feasible, we encourage individual consortia to consolidate all travel expenses for their research group and submit a single collective claim to the RSF team for reimbursement. The RSF will then process reimbursements up to the value of £150 for each consortium member who traveled.
 


### PR DESCRIPTION
Took me a while, but I finally copied it over 😅 

I think it's currently a bit unclear:
- how people apply for the accessibility fund - should this be part of the registration form?
- in the "If you're sending the forms and receipts to RSF team (aimrsf@turing.ac.uk) independently and not through your consortium project manager, please make sure that you use DocuSign and complete all docs. You should have received an email from DocuSign with all docs." part - at what point of time is this supposed to happen? The "You should have received an email from DocuSign with all docs." could be confusing if they don't know when they're supposed to have received these forms. (And how do we know to send the forms to people?)

This is minor, but the links for the forms that people need to submit to claim back expenses are from the conference website - is there a different place where we can store these? Just in case something changes with that website